### PR TITLE
Discover google cloud service plans with warning

### DIFF
--- a/create_price_sets.py
+++ b/create_price_sets.py
@@ -30,8 +30,12 @@ import json
 import logging
 import requests
 import time
-from typing import Dict, List, Any, Optional
+import urllib3
+from typing import Optional, Dict, Any, List
 from collections import defaultdict
+
+# Disable SSL warnings for self-signed certificates
+urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
 
 # Configure logging
 logging.basicConfig(
@@ -51,6 +55,9 @@ class MorpheusAPIClient:
             'Authorization': f'Bearer {token}',
             'Content-Type': 'application/json'
         })
+        # Disable SSL verification for self-signed certificates
+        self.session.verify = False
+        logger.warning("SSL certificate verification disabled - this is acceptable for self-signed certificates but should be used with caution in production")
     
     def make_request(self, method: str, endpoint: str, data: Dict = None, params: Dict = None, max_retries: int = 3) -> requests.Response:
         """Make HTTP request with retry logic"""
@@ -58,12 +65,18 @@ class MorpheusAPIClient:
         
         for attempt in range(max_retries):
             try:
-                response = self.session.request(method, url, json=data, params=params)
+                response = self.session.request(method, url, json=data, params=params, verify=False)
                 logger.debug(f"{method} {url} - Status: {response.status_code}")
                 
                 if response.status_code < 500:  # Don't retry on client errors
                     return response
                     
+            except requests.exceptions.SSLError as e:
+                if "CERTIFICATE_VERIFY_FAILED" in str(e):
+                    logger.warning(f"SSL certificate verification failed (attempt {attempt + 1}/{max_retries}): {e}")
+                    logger.warning("This is expected behavior with self-signed certificates - continuing with verification disabled")
+                else:
+                    logger.warning(f"SSL error (attempt {attempt + 1}/{max_retries}): {e}")
             except requests.exceptions.RequestException as e:
                 logger.warning(f"Request failed (attempt {attempt + 1}/{max_retries}): {e}")
                 

--- a/create_prices.py
+++ b/create_prices.py
@@ -30,7 +30,11 @@ import json
 import logging
 import requests
 import time
-from typing import Dict, List, Any, Optional, Tuple
+import urllib3
+from typing import Optional, Dict, Any, List, Tuple
+
+# Disable SSL warnings for self-signed certificates
+urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
 
 # Configure logging
 logging.basicConfig(
@@ -50,6 +54,9 @@ class MorpheusAPIClient:
             'Authorization': f'Bearer {token}',
             'Content-Type': 'application/json'
         })
+        # Disable SSL verification for self-signed certificates
+        self.session.verify = False
+        logger.warning("SSL certificate verification disabled - this is acceptable for self-signed certificates but should be used with caution in production")
     
     def make_request(self, method: str, endpoint: str, data: Dict = None, params: Dict = None, max_retries: int = 3) -> requests.Response:
         """Make HTTP request with retry logic"""
@@ -57,12 +64,18 @@ class MorpheusAPIClient:
         
         for attempt in range(max_retries):
             try:
-                response = self.session.request(method, url, json=data, params=params)
+                response = self.session.request(method, url, json=data, params=params, verify=False)
                 logger.debug(f"{method} {url} - Status: {response.status_code}")
                 
                 if response.status_code < 500:  # Don't retry on client errors
                     return response
                     
+            except requests.exceptions.SSLError as e:
+                if "CERTIFICATE_VERIFY_FAILED" in str(e):
+                    logger.warning(f"SSL certificate verification failed (attempt {attempt + 1}/{max_retries}): {e}")
+                    logger.warning("This is expected behavior with self-signed certificates - continuing with verification disabled")
+                else:
+                    logger.warning(f"SSL error (attempt {attempt + 1}/{max_retries}): {e}")
             except requests.exceptions.RequestException as e:
                 logger.warning(f"Request failed (attempt {attempt + 1}/{max_retries}): {e}")
                 

--- a/discover_service_plans.py
+++ b/discover_service_plans.py
@@ -26,7 +26,11 @@ import json
 import logging
 import requests
 import time
+import urllib3
 from typing import Optional, Dict, Any, List
+
+# Disable SSL warnings for self-signed certificates
+urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
 
 # Configure logging
 logging.basicConfig(
@@ -46,6 +50,9 @@ class MorpheusAPIClient:
             'Authorization': f'Bearer {token}',
             'Content-Type': 'application/json'
         })
+        # Disable SSL verification for self-signed certificates
+        self.session.verify = False
+        logger.warning("SSL certificate verification disabled - this is acceptable for self-signed certificates but should be used with caution in production")
     
     def make_request(self, method: str, endpoint: str, data: Dict = None, params: Dict = None, max_retries: int = 3) -> requests.Response:
         """Make HTTP request with retry logic"""
@@ -53,12 +60,18 @@ class MorpheusAPIClient:
         
         for attempt in range(max_retries):
             try:
-                response = self.session.request(method, url, json=data, params=params)
+                response = self.session.request(method, url, json=data, params=params, verify=False)
                 logger.debug(f"{method} {url} - Status: {response.status_code}")
                 
                 if response.status_code < 500:  # Don't retry on client errors
                     return response
                     
+            except requests.exceptions.SSLError as e:
+                if "CERTIFICATE_VERIFY_FAILED" in str(e):
+                    logger.warning(f"SSL certificate verification failed (attempt {attempt + 1}/{max_retries}): {e}")
+                    logger.warning("This is expected behavior with self-signed certificates - continuing with verification disabled")
+                else:
+                    logger.warning(f"SSL error (attempt {attempt + 1}/{max_retries}): {e}")
             except requests.exceptions.RequestException as e:
                 logger.warning(f"Request failed (attempt {attempt + 1}/{max_retries}): {e}")
                 


### PR DESCRIPTION
Allow scripts to proceed with self-signed SSL certificates by disabling verification and logging warnings.

Previously, scripts would fail when encountering self-signed certificates. This change enables them to run in environments where self-signed certificates are common (e.g., development/testing) by logging a warning and continuing, rather than aborting.

---
<a href="https://cursor.com/background-agent?bcId=bc-981248f0-7575-4c37-8293-966225417dcc">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-981248f0-7575-4c37-8293-966225417dcc">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

